### PR TITLE
Remove the extra space around mark

### DIFF
--- a/assets/css/helper/_global.scss
+++ b/assets/css/helper/_global.scss
@@ -29,6 +29,7 @@ pre, code {
 
 mark {
   padding: 2px;
+  margin: -2px;
   color: inherit;
   background-color: rgba(yellow, .4);
 }


### PR DESCRIPTION
The padding can stay, it's nice, but it would be nice to not have gaps
in words.

This image clearly shows the issue:

![image](https://user-images.githubusercontent.com/18674/62143647-ae704800-b2f0-11e9-9af6-3e0fd2740ae7.png)

With this fix applied it looks like this:

![image](https://user-images.githubusercontent.com/18674/62143708-ce077080-b2f0-11e9-89bc-acfd0d15d2d0.png)

