### PR TITLE
filter: replace spaces with dashes & allow dots

### DIFF
--- a/app.cr
+++ b/app.cr
@@ -40,7 +40,7 @@ end
 
 def fetch_filter(env)
   filter = env.params.query["filter"]?.try(&.to_s.strip.downcase) || ""
-  filter.gsub(" ", "-").gsub(/[^a-z0-9\_\-]/i, "")
+  filter.gsub(" ", "-").gsub(/[^a-z0-9\_\-\.]/i, "")
 end
 
 def fetch_page(env)

--- a/app.cr
+++ b/app.cr
@@ -40,7 +40,7 @@ end
 
 def fetch_filter(env)
   filter = env.params.query["filter"]?.try(&.to_s.strip.downcase) || ""
-  filter.gsub(/[^a-z0-9\_\-]/i, "")
+  filter.gsub(" ", "-").gsub(/[^a-z0-9\_\-]/i, "")
 end
 
 def fetch_page(env)


### PR DESCRIPTION
Searching for `awesome crystal` should return https://github.com/veelenga/awesome-crystal, however due to the current filter, it gets converted into `awesomecrystal`.

This PR replaces spaces with dashes.

This also follows the GitHub naming scheme:
![create-repo-screen](https://i.imgur.com/oX7o0Go.png)

carc.in: https://carc.in/#/r/9x3w

Also, same issue with `jennifer.cr` which gets converted to `jennifercr` and doesn't return the repo.

carc.in: https://carc.in/#/r/9x3x